### PR TITLE
LangGraph 오류 수정, 프롬프트 개선

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ profile = "black"
 
 [dependency-groups]
 dev = [
+    "langsmith>=0.3.32",
     "pre-commit>=4.2.0",
     "pytest>=8.3.5",
     "pytest-env>=1.1.5",

--- a/server/prompts/genai_query_prompt.txt
+++ b/server/prompts/genai_query_prompt.txt
@@ -1,1 +1,15 @@
-Be direct and concise - get to the point. You don't have to answer the entire question. State only the key ideas needed to answer the question. 
+Provide essential ideas and facts needed to answer the latest user query. 
+
+Use the preceding conversation history for context and prioritize information from any provided reference documents. 
+
+Reference documents are provided within <reference>, </reference>. The chat history follows the reference documents. 
+
+If reference documents are provided, your summary MUST be primarily based on the documents.
+
+If the documents provide sufficient information, avoid introducing external knowledge.
+
+If reference documents are NOT provided, or if they do not fully cover the latest user query, use your general knowledge (informed by the conversation context) to identify and state the key ideas.
+
+Output Requirements:
+ - Concise and Direct: Get straight to the point. Avoid conversational fluff, greetings, or apologies.
+ - Key Ideas Only: Your output should be a list of key points or a brief paragraph summarizing the core information. 

--- a/server/prompts/pre_retrieve_prompt.txt
+++ b/server/prompts/pre_retrieve_prompt.txt
@@ -1,0 +1,15 @@
+Analyze the provided conversation history which culminates in the latest user question to determinei if retrieving external documents is necessary to provide a comprehensive answer. 
+
+Review the ENTIRE conversation history to understand the full context.
+Focus on the LATEST user question (the last message in the history).
+Decide if external documents need to be retrieved to answer this LATEST question. 
+
+Note that the external documents are provided by the user and are likely to contain relevant information. 
+If retrieval IS needed (e.g., the question is specific, requires recent information, or you want to be sure): 
+   - Generate a concise search query based on the latest user question and the conversation history.
+   - Make a tool call to `retrieve`.
+If retrieval IS NOT needed (e.g., the question is general): 
+   - Respond with the single word: PASS
+   - Do NOT add any other text or explanation if you output PASS.
+
+The conversation history is as follows:

--- a/server/prompts/teacher_prompt.txt
+++ b/server/prompts/teacher_prompt.txt
@@ -2,26 +2,85 @@ You are a teacher that always responds in the Socratic style.
 A Socratic teacher: 
  - does not directly disclose the answers
  - ask questions that probes the student's thinking, determines the extent of the student's knowledge
+ - may explain background knowledge that the student doesn't know
 You should only generate a Teacher's response, not the Student's response. 
-The student's initial question is given between the tags <query>, </query>. 
-Key ideas for answering the Student's question is given between the tags <answer>, </answer>. 
+Key ideas for answering the LATEST Student's question is given between the tags <answer>, </answer>. 
 The answer part should not be disclosed directly. 
 You should answer using the provided reference between the tags <reference>, </reference> if it is provided.
 
-<query>How do I solve the following algorithmic problem in C++?
+<answer>* To maximize N (the number of different natural numbers whose sum is S), select the smallest natural numbers: 1, 2, 3, ..., N.
+* The sum of the first N natural numbers is given by the formula N(N+1)/2.
+* The largest N such that N(N+1)/2 ≤ S is the answer.
+* A naive approach is to increment N until the sum exceeds S, but this is inefficient for large S.
+* Since N(N+1)/2 is strictly increasing, binary search can be used to find the maximum N such that N(N+1)/2 ≤ S efficiently in O(log S) time.
+</answer>
+[Student]: How do I solve the following algorithmic problem in C++?
 
 Let S be the sum of N different natural numbers. Given S, what is the maximum value of the natural number N?
 Input: The natural number S (1 ≤ S ≤ 4,294,967,295) is given in the first line.
-Output: Print the maximum value of the natural number N on line 1.</query>
-<answer>Key idea: Use two pointers, one to track the position of the next unique element and another to iterate through the array.</answer>
-[Teacher]: What are we trying to find?
-[Student]: We are trying to find the largest number N such that the sum of N natural numbers become S.
+Output: Print the maximum value of the natural number N on line 1.
 [Teacher]: To maximize N, what kind of numbers should we take?
 [Student]: We should take the smallest numbers first, so we would take 1, 2, 3, .... Oh, then I may sum 1 + 2 + 3 + ... until the sum is less than or equal to S. Then, we can take S minus the sum as our last number to take. Right?
 [Teacher]: Yes, I think you are on the right track! What's the time complexity of your method? Is there a way to make it more efficient?
 [Student]: Well, I can find the sum from 1 to N using the formula N(N+1)/2. But still the fact that we need to try N=1, 2, 3, ... doesn't change. So I think it is the most efficient way. The time complexity would be O(sqrt(S)).
 [Teacher]: Well, S is limited to 4,294,967,295 and the sequence N(N+1)/2 is an increasing sequence. This looks like an ordered list. Is sequential search on an ordered list efficient?
 [Student]: Now I see. We can perform binary search on the sequence N(N+1)/2. Then the time complexity would become O(log S). 
-[Teacher]: Good. Now why don't you try implementing this?
-[Student]: Okay!
-[Teacher]: [END]
+
+<answer>* Hash tables rely on a hash function to map keys to slots; ideally, each key maps to a unique slot, allowing O(1) lookup time on average.
+* When multiple keys are mapped to the same slot (a collision), they must be stored together, usually in a list or similar structure.
+* If many keys collide and end up in the same slot, searching through that slot can take O(n) time in the worst case, where n is the number of elements.
+* Therefore, while average lookup is O(1) with a good hash function and low collisions, the worst-case lookup becomes O(n) due to collisions.</answer>
+
+<reference>
+<source>hash_table.html</source>
+<content>In computer science, a hash table is a data structure that implements an associative array, also called a dictionary or simply map; an associative array is an abstract data type that maps keys to values.[3] A hash table uses a hash function to compute an index, also called a hash code, into an array of buckets or slots, from which the desired value can be found. During lookup, the key is hashed and the resulting hash indicates where the corresponding value is stored. A map implemented by a hash table is called a hash map.</content>
+<source>hash_table.html</source>
+<content>In a well-dimensioned hash table, the average time complexity for each lookup is independent of the number of elements stored in the table. Many hash table designs also allow arbitrary insertions and deletions of key–value pairs, at amortized constant average cost per operation.[4][5][6]</content>
+</reference>
+
+[Student]: Why is it that hash tables can achieve O(1) average lookup time, but not in the worst case?
+[Teacher]: Let's consider what happens when you look up a value in a hash table. In the best or average case, what does the hash function do with your key, and where does it send you? Now, think about the cases when many keys end up being mapped to the same location. What happens then? What would cause a situation where multiple keys “collide” to the same slot, and how would that affect the time it takes to find your value?
+[Student]: I'm not sure about what would happen when may keys map to the same location. 
+[Teacher]: If several keys are assigned to the same slot in the hash table, do you think the table can immediately retrieve the value with just one operation, or is there something extra it needs to do? How do you suppose those values are stored when they collide in the same position, and what does that mean for how many steps it might take to find a particular value among them?
+
+<answer>* Model capacity refers to the number of parameters or the complexity a model can represent.
+* Increasing capacity allows the model to fit more complex patterns in the training data.
+* When capacity is too high, the model can memorize noise and random fluctuations in the training data, not just the true underlying patterns.
+* As a result, while the model may achieve very low error on the training set, its performance on new, unseen data (generalization) can degrade.
+* This phenomenon is known as overfitting: fitting the training data too closely, including its noise, and failing to generalize to new data.
+</answer>
+<reference>
+<source>lec01 ml basics.pdf</source>
+<content>Capacity, Overfitting and Underfitting
+Goal:
+I Perform well on new, previously
+unseen inputs (test set, blue), not
+only on the training set (green)
+I This is called generalization and
+separates ML from optimization
+I Assumption: training and test data
+independent and identically (i.i.d.)
+drawn from distribution pdata(x, y)
+I Here: pdata(x) = U (0, 1)
+pdata(y|x) = N (sin(2\pi x), \sigma)</content>
+<source>lec01 ml basics.pdf</source>
+<content>General Approach: Split dataset into training, validation and test set
+I Choose hyperparameters (e.g., degree of polynomial, learning rate in neural net, ..)
+using validation set. Important: Evaluate once on test set (typically not available).
+I When dataset is small, use (k-fold) cross validation instead of fixed split.</content>
+</reference>
+
+[Student]: Why does increasing model capacity beyond a certain point often lead to overfitting?
+[Teacher]: What do you think it means for a model to have more "capacity"? If a model becomes powerful enough to fit almost any pattern in the data—even random or meaningless fluctuations—what do you expect will happen?
+[Student]: Model capacity typically stands for the number of learnable parameters, right? If a model is large enough to capture the pattern in the data perfectly, isn't it a perfect model? 
+
+<answer>* Disk accesses are orders of magnitude slower than memory accesses; minimizing the number of disk reads is critical.
+* Binary search trees (BSTs) have low time complexity for search (O(log n)), but their structure often leads to poor locality, resulting in many disk reads because each node is stored separately and tree height is high.
+* B+ trees are designed to be wide (high branching factor) and shallow, packing many keys into each node so that each disk read brings in many keys at once, minimizing the total number of disk accesses.
+* B+ tree nodes align with disk block sizes, optimizing I/O efficiency.
+* As a result, B+ trees require far fewer disk reads than BSTs for the same number of entries, making them far superior for disk-based indexing.
+</answer>
+
+[Student]: Why are B+ trees favored over binary search trees for indexing on disk?
+[Teacher]: When we think about data structures for indexing data stored on disk, what are the main factors that make disk access expensive compared to memory access? Given that, do you think it’s more efficient to read small pieces of data from many places, or larger contiguous blocks all at once?
+[Student]: I know that every disk read is expensive, and we should go for minimum reads. But isn't binary search trees also designed to have low time complexity?

--- a/server/services/langgraph_service.py
+++ b/server/services/langgraph_service.py
@@ -273,7 +273,6 @@ class LangGraphService:
         full_prompt = "\n".join(
             [
                 instruction,
-                f"<query>{user_query}</query>",
                 f"<answer>{initial_answer}</answer>",
                 docs_content,
                 history + "[Teacher]: ",

--- a/server/services/langgraph_service.py
+++ b/server/services/langgraph_service.py
@@ -5,12 +5,12 @@ from langchain_core.messages import (
     AIMessage,
     AnyMessage,
     HumanMessage,
-    RemoveMessage,
     ToolMessage,
 )
 from langchain_core.tools import tool
 from langgraph.graph import END, StateGraph
 from langgraph.graph.message import add_messages
+from langgraph.graph.state import CompiledStateGraph
 from langgraph.prebuilt import InjectedState, ToolNode
 
 from server.repositories.vector_store import vector_store
@@ -31,7 +31,7 @@ class LangGraphService:
         self.graph = self._build_graph()
         self.prompt_service = PromptService()
 
-    def _build_graph(self) -> StateGraph:
+    def _build_graph(self) -> CompiledStateGraph:
         """Build and compile the LangGraph."""
         graph_builder = StateGraph(State)
 
@@ -41,7 +41,6 @@ class LangGraphService:
         graph_builder.add_node("tools", self._create_tool_node())
         graph_builder.add_node("generate_initial_answer", self._generate_initial_answer)
         graph_builder.add_node("generate_final_answer", self._generate_final_answer)
-        graph_builder.add_node("cleanup_messages", self._cleanup_messages)
 
         # Set entry point
         graph_builder.set_entry_point("load_chat_history")
@@ -55,8 +54,7 @@ class LangGraphService:
         )
         graph_builder.add_edge("tools", "generate_initial_answer")
         graph_builder.add_edge("generate_initial_answer", "generate_final_answer")
-        graph_builder.add_edge("generate_final_answer", "cleanup_messages")
-        graph_builder.add_edge("cleanup_messages", END)
+        graph_builder.add_edge("generate_final_answer", END)
 
         return graph_builder.compile()
 
@@ -64,12 +62,18 @@ class LangGraphService:
     def _create_tool_node() -> ToolNode:
         """Create a tool node for document retrieval."""
 
-        @tool
+        @tool(response_format="content_and_artifact")
         def retrieve(
             query: str,
             collection_name: Annotated[str, InjectedState("collection_name")],
         ):
-            """Retrieves relevant documents uploaded by the user based on the query."""
+            """
+            Retrieves relevant documents uploaded by the user based on the query.
+
+            Args:
+                query: The query to search for relevant documents.
+                collection_name: The name of the collection to search in.
+            """
             print(
                 f"--- Retrieving documents for query: '{query}' in collection: "
                 f"'{collection_name}' ---"
@@ -81,10 +85,16 @@ class LangGraphService:
                 f"--- Retrieved {len(retrieved_docs)} documents from collection "
                 f"'{collection_name}' ---"
             )
-            return [
-                {"page_content": doc.page_content, "metadata": doc.metadata}
-                for doc in retrieved_docs
-            ]
+
+            content = ""
+            if retrieved_docs:
+                content = "\n\n".join(
+                    f"<source>{doc.metadata.get('source', 'N/A')}</source>"
+                    + f"<content>{doc.page_content}</content>"
+                    for doc in retrieved_docs
+                )
+
+            return content, retrieved_docs
 
         return ToolNode([retrieve])
 
@@ -121,13 +131,14 @@ class LangGraphService:
 
     def _pre_retrieve(self, state: State) -> Dict[str, List[AnyMessage]]:
         """
-        Given the query, decide whether to retrieve documents or use LLM knowledge.
+        Given the full conversation history, decide whether to retrieve documents
+        to answer the latest user query. If so, generate a history-informed
+        search query.
         """
-        print("--- Pre-retrieve: Analyzing query ---")
-        user_query = state.get("user_query")
-        if not user_query:
-            print("Error: No user query found in state for pre_retrieve")
-            raise ValueError("User query not found in state")
+        all_messages = state.get("messages", [])
+        if not all_messages:
+            print("Error: No messages found in state for pre_retrieve")
+            raise ValueError("Messages not found in state for pre_retrieve")
 
         collection_name = state.get("collection_name")
         if not collection_name:
@@ -138,107 +149,10 @@ class LangGraphService:
             [self._create_tool_node().tools_by_name["retrieve"]]
         )
 
-        prompt = (
-            "You are an assistant that decides whether external knowledge is needed to",
-            "answer a question.\n",
-            "Given the following question, decide if you need to search for additional",
-            "context from documents.\n",
-            "If document retrieval is needed, call the retrieve tool with a",
-            "well-formed search query.\n\n",
-            f"Question: {user_query}\n\n",
-            "Think carefully - if this is a question about specific information that",
-            "might be in the uploaded documents,",
-            "use the retrieve tool. If it's general knowledge or doesn't require",
-            "specific document content, answer simply 'PASS'.\n",
-        )
-
-        response = llm_with_tools.invoke([HumanMessage(content=prompt)])
-        return {"messages": [response]}
-
-    def _generate_initial_answer(self, state: State) -> Dict[str, str]:
-        """Generate the initial concise answer to the user's query."""
-        user_query = state.get("user_query")
-        if not user_query:
-            print("Error: user_query not found in state for generate_initial_answer")
-            raise ValueError("User query not found in state")
-
-        # Check if there are tool messages (retrieval results)
-        recent_tool_messages = []
-        for message in reversed(state.get("messages", [])):
-            if isinstance(message, ToolMessage):
-                recent_tool_messages.append(message)
-            else:
-                break
-        tool_messages = recent_tool_messages[::-1]
-
-        # Format retrieved documents if any
-        docs_content = ""
-        if tool_messages:
-            docs_content = "\n\n".join(
-                f"Source: {res['metadata'].get('source', 'N/A')}, "
-                f"Split Index: {res['metadata'].get('split_idx', 'N/A')}\n"
-                f"Content: {res['page_content']}\n"
-                for msg in tool_messages
-                for res in (msg.content if isinstance(msg.content, list) else [])
-                if isinstance(res, dict)
-            )
-            docs_content = f"<reference>{docs_content}</reference>\n"
-
-        # Generate initial answer
-        prompt_template = self.prompt_service.get_prompt("genai_query_prompt.txt")
-        msg_content = prompt_template + f"\n\n{user_query}\n\n{docs_content}"
-        response = llm.invoke([HumanMessage(content=msg_content)])
-        answer = response.content
-
-        print("--- Initial Answer Generated ---")
-        return {"initial_answer": answer}
-
-    def _generate_final_answer(self, state: State) -> Dict[str, List[AIMessage]]:
-        """
-        Generate the final response using teacher prompt, initial answer, and retrieval
-        results.
-        """
-        print("--- Teacher: Generating Response with Context ---")
-        user_query = state.get("user_query")
-        initial_answer = state.get("initial_answer")
-
-        if not user_query or not initial_answer:
-            print(
-                "Error: missing user_query or initial_answer in generate_final_answer"
-            )
-            raise ValueError("Missing required state elements")
-
-        recent_tool_messages = []
-        for message in reversed(state.get("messages", [])):
-            if isinstance(message, ToolMessage):
-                recent_tool_messages.append(message)
-            else:
-                break
-        tool_messages = recent_tool_messages[::-1]
-
-        # Format retrieved documents
-        docs_content = ""
-        if tool_messages:
-            docs_content = "\n\n".join(
-                f"Source: {res['metadata'].get('source', 'N/A')}, "
-                f"Split Index: {res['metadata'].get('split_idx', 'N/A')}\n"
-                f"Content: {res['page_content']}\n"
-                for msg in tool_messages
-                for res in (msg.content if isinstance(msg.content, list) else [])
-                if isinstance(res, dict)
-            )
-            docs_content = f"<reference>{docs_content}</reference>\n"
-
-        template = self.prompt_service.get_prompt("teacher_prompt.txt")
-        template += f"<query>{user_query}</query>\n"
-        template += f"<answer>{initial_answer}</answer>\n"
-        template += docs_content
+        instruction = self.prompt_service.get_prompt("pre_retrieve_prompt.txt")
 
         history = ""
-        messages_for_history = [
-            m for m in state.get("messages", []) if not isinstance(m, ToolMessage)
-        ]
-        for message in messages_for_history:
+        for message in all_messages:
             if isinstance(message, HumanMessage):
                 history += f"[Student]: {message.content}\n"
             elif (
@@ -248,43 +162,127 @@ class LangGraphService:
             ):
                 history += f"[Teacher]: {message.content}\n"
 
-        message_content = template + history + "[Teacher]: "
-        response = llm.invoke([HumanMessage(message_content)])
+        full_prompt = f"{instruction}\n{history}\n"
 
-        student_part_start_idx = response.content.find("[Student]")
-        if student_part_start_idx != -1:
-            response.content = response.content[:student_part_start_idx].strip()
+        print(f"--- Pre-retrieve: Analyzing {len(all_messages)} messages. ---")
 
+        # Invoke the LLM with the instruction and the full conversation history
+        response = llm_with_tools.invoke([HumanMessage(content=full_prompt)])
+
+        # The response is an AIMessage, which might contain tool calls
+        # or the content "PASS".
         return {"messages": [response]}
 
-    def _cleanup_messages(self, state: State) -> Dict[str, List[RemoveMessage]]:
+    def _generate_initial_answer(self, state: State) -> Dict[str, str]:
         """
-        Clean up the message history by removing tool calls, tool messages, and 'PASS'
-        messages."""
-        print("--- Cleaning up message history ---")
+        Generate the initial concise answer to the user's query,
+        using conversation history.
+        """
+        user_query = state.get("user_query")
+        if not user_query:
+            print("Error: user_query not found in state for generate_initial_answer")
+            raise ValueError("User query not found in state")
 
-        messages = state.get("messages", [])
-        message_to_remove_ids = []
+        all_messages = state.get("messages", [])
+        if not all_messages:
+            print("Error: No messages found in state for generate_initial_answer")
+            raise ValueError("Messages not found in state")
 
-        for message in messages:
-            # Remove AI messages with tool calls
-            if isinstance(message, AIMessage) and message.tool_calls:
-                message_to_remove_ids.append(message.id)
-
-            # Remove Tool Messages
-            elif isinstance(message, ToolMessage):
-                message_to_remove_ids.append(message.id)
-
-            # Remove AI messages that just say "PASS"
+        history = ""
+        for message in all_messages:
+            if isinstance(message, HumanMessage):
+                history += f"[Student]: {message.content}\n"
             elif (
                 isinstance(message, AIMessage)
-                and message.content.strip().lower() == "pass"
+                and not message.tool_calls
+                and not message.content.strip().lower() == "pass"
             ):
-                message_to_remove_ids.append(message.id)
+                history += f"[Teacher]: {message.content}\n"
 
-        # Create RemoveMessage objects for each index to remove
-        remove_messages = [RemoveMessage(id=id) for id in message_to_remove_ids]
-        return {"messages": remove_messages}
+        # Check if there are tool messages (retrieval results)
+        recent_tool_messages = []
+        for message in reversed(all_messages):  # Check all_messages for ToolMessages
+            if isinstance(message, ToolMessage):
+                recent_tool_messages.append(message)
+            else:
+                break
+        tool_messages = recent_tool_messages[::-1]
+
+        # Format retrieved documents if any
+        docs_content = ""
+        if tool_messages:
+            docs_content = "\n".join(tool_msg.content for tool_msg in tool_messages)
+            docs_content = f"<reference>{docs_content}</reference>\n"
+
+        # Generate initial answer
+        instruction = self.prompt_service.get_prompt("genai_query_prompt.txt")
+
+        full_prompt = f"{instruction}\n{docs_content}\n{history}\n"
+        response = llm.invoke([HumanMessage(content=full_prompt)])
+        answer = response.content
+
+        print(f"--- Initial Answer Generated (for query: '{user_query}') ---")
+        return {"initial_answer": answer}
+
+    def _generate_final_answer(self, state: State) -> Dict[str, List[AIMessage]]:
+        """
+        Generate the final response using teacher prompt, initial answer, and retrieval
+        results.
+        """
+        print("--- Teacher: Generating Response with Context ---")
+        user_query = state.get("user_query")
+        if not user_query:
+            print("Error: user_query not found in state for generate_final_answer")
+            raise ValueError("User query not found in state")
+        initial_answer = state.get("initial_answer")
+        if not initial_answer:
+            print("Error: initial_answer not found in state for generate_final_answer")
+            raise ValueError("Initial answer not found in state")
+        all_messages = state.get("messages", [])
+        if not all_messages:
+            print("Error: No messages found in state for generate_final_answer")
+            raise ValueError("Messages not found in state")
+
+        recent_tool_messages = []
+        for message in reversed(all_messages):
+            if isinstance(message, ToolMessage):
+                recent_tool_messages.append(message)
+            else:
+                break
+        tool_messages = recent_tool_messages[::-1]
+
+        # Format retrieved documents if any
+        docs_content = ""
+        if tool_messages:
+            docs_content = "\n".join(tool_msg.content for tool_msg in tool_messages)
+            docs_content = f"<reference>{docs_content}</reference>\n"
+
+        history = ""
+        for message in all_messages:
+            if isinstance(message, HumanMessage):
+                history += f"[Student]: {message.content}\n"
+            elif (
+                isinstance(message, AIMessage)
+                and not message.tool_calls
+                and not message.content.strip().lower() == "pass"
+            ):
+                history += f"[Teacher]: {message.content}\n"
+
+        instruction = self.prompt_service.get_prompt("teacher_prompt.txt")
+
+        full_prompt = "\n".join(
+            [
+                instruction,
+                f"<query>{user_query}</query>",
+                f"<answer>{initial_answer}</answer>",
+                docs_content,
+                history + "[Teacher]: ",
+            ]
+        )
+
+        response = llm.invoke([HumanMessage(full_prompt)])
+
+        return {"messages": [response]}
 
     @staticmethod
     def _route_after_query(state: State) -> Literal["tools", "generate_initial_answer"]:
@@ -318,7 +316,8 @@ class LangGraphService:
 
         Args:
             chat_id: Identifier for the chat/collection
-            user_message: The message from the user
+            user_message: The message from the user. This is already written in the
+            chat history.
 
         Yields:
             Tokens from the AI response as they're generated
@@ -328,7 +327,6 @@ class LangGraphService:
             stream_input = {
                 "user_query": user_message,
                 "collection_name": chat_id,
-                "messages": [HumanMessage(content=user_message)],
             }
 
             # Stream the response from the graph with token-by-token streaming

--- a/uv.lock
+++ b/uv.lock
@@ -2582,6 +2582,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "langsmith" },
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-env" },
@@ -2612,6 +2613,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "langsmith", specifier = ">=0.3.32" },
     { name = "pre-commit", specifier = ">=4.2.0" },
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "pytest-env", specifier = ">=1.1.5" },


### PR DESCRIPTION
## 📝 작업 목록
- [x] LangGraph 오류 수정
  - retrieve tool: tool이 string을 리턴하지 않아 retrieved document를 못 쓰던 문제 → retrieved documents stringify, document object도 그대로 사용할 수 있도록 content_and_artifact로 수정
  - stream_chat_response에서 graph input 중 messages에 사용자 메시지 넣는 실수 → 제거
- [x] LangGraph 기능 수정
  - pre-retrieve 단계: ~~마지막 유저 쿼리 활용~~ 대화 전체 활용
  - generate-initial-answer 단계: ~~마지막 유저 쿼리 활용~~ 대화 전체 활용
- [x] LangGraph 자잘한 수정
  - generate-final-answer 단계: 
    - 사용자의 마지막 질문 담는 `<query>{user_query></query>`는 대화기록 마지막에도 있어 중복되므로 제거
    - [Student]로 시작하는 파트 등 생성하면 안되는데 생성하는 부분을 제거하는 로직이 있는데, response를 streaming하고 있어 이 로직을 활용하지 않고 있으므로 혼란 방지 위해 삭제
  - cleanup-messages 단계: 실제 활용되지 않아 삭제
- [x] 프롬프트 수정
  - pre-retrieve 단계(pre_retrieve_prompt.txt): 대화 기록을 활용하도록 수정
  - generate-initial-answer 단계(genai_query_prompt.txt): Retrieved document가 무엇인지 설명하고 어떻게 활용해야하는지 추가
  - generate-final-answer 단계(teacher_prompt.txt): 
    - 배경지식 설명할 수 있다고 명시
    - `<query>{user_query></query>` 제거를 반영해 관련된 라인 제거
    - 알고리즘, 자료구조, 머신러닝 분야에 대한 few-shot 추가
     - 적절한 초기답안(`<answer>`), 관련성 높은/낮은 참고문서(`<reference>`) 추가

## 🔗 관련 이슈
- Closes #35 