### PR TITLE
새 파일 업로드 로직 구현, 마크다운 내용 가져오는 엔드포인트 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 1. `pip install uv`
 2. `uv sync`
 3. `uv run pre-commit install`
-4. `uv run uvicorn main:app`
+4. `uv run uvicorn server.main:app --reload`
 
 
 ## Setup docker compsose

--- a/server/models/document_model.py
+++ b/server/models/document_model.py
@@ -43,3 +43,16 @@ class DocumentResponse(BaseModel):
     upload_date: str = Field(
         ..., alias="uploadDate", description="Document upload date"
     )
+
+
+class MarkdownContentResponse(BaseModel):
+    """
+    Response model for markdown content.
+    """
+
+    filename: str = Field(..., description="Filename of the document")
+    size: int = Field(..., description="Size of the document file in bytes")
+    file_content: str = Field(..., description="Markdown content of the document")
+    upload_date: str = Field(
+        ..., alias="uploadDate", description="Upload date of the document"
+    )

--- a/server/models/document_model.py
+++ b/server/models/document_model.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from fastapi import UploadFile
 from pydantic import BaseModel, Field
 from sqlalchemy import Column, DateTime, Integer, String, func
@@ -43,16 +45,6 @@ class DocumentResponse(BaseModel):
     upload_date: str = Field(
         ..., alias="uploadDate", description="Document upload date"
     )
-
-
-class MarkdownContentResponse(BaseModel):
-    """
-    Response model for markdown content.
-    """
-
-    filename: str = Field(..., description="Filename of the document")
-    size: int = Field(..., description="Size of the document file in bytes")
-    file_content: str = Field(..., description="Markdown content of the document")
-    upload_date: str = Field(
-        ..., alias="uploadDate", description="Upload date of the document"
+    markdown_content: Optional[str] = Field(
+        ..., description="Markdown content of the document"
     )

--- a/server/routers/document.py
+++ b/server/routers/document.py
@@ -1,11 +1,11 @@
 from fastapi import APIRouter, Depends, File, Path, UploadFile
-from fastapi.responses import JSONResponse
 from sqlalchemy.orm import Session
 
-from server.models.document_model import DocumentResponse
+from server.models.document_model import DocumentResponse, MarkdownContentResponse
 from server.services.document import (
     delete_document,
     get_document_metadata,
+    get_markdown_document_metadata,
     list_documents,
     upload_and_register_document,
 )
@@ -75,4 +75,22 @@ def delete_document_route(
     Delete a specific resource from a project
     """
     delete_document(db, projectId, filename)
-    return JSONResponse(status_code=204, content=None)
+    return None
+
+
+@router.get("/{filename}/md", response_model=MarkdownContentResponse)
+def get_markdown(
+    projectId: str = Path(..., description="Project ID"),
+    filename: str = Path(..., description="Original file name(e.g. PDF)"),
+    db: Session = Depends(get_db),
+):
+    """
+    Get markdown content of a specific resource
+    """
+    doc = get_markdown_document_metadata(db, projectId, filename)
+    return {
+        "filename": doc["filename"],
+        "uploadDate": doc["upload_date"].isoformat(),
+        "file_content": doc["file_content"],
+        "size": doc["size"],
+    }

--- a/server/services/document.py
+++ b/server/services/document.py
@@ -1,10 +1,15 @@
+import asyncio
+import re
 from datetime import timedelta
 from io import BytesIO
 
+import httpx
 from fastapi import HTTPException, UploadFile
 from langchain_core.retrievers import BaseRetriever
+from minio.error import S3Error
 from sqlalchemy.orm import Session
 
+from server.models.document_model import Document
 from server.repositories.document_store import (
     create_document,
     delete_document_by_filename,
@@ -12,7 +17,7 @@ from server.repositories.document_store import (
     get_documents_by_project,
 )
 from server.repositories.vector_store import vector_store
-from server.services.vector_store import add_file_to_vector_store
+from server.utils.config import PARSE_SERVER_BASE_URL
 from server.utils.db import MINIO_URL, minio_client
 
 
@@ -36,6 +41,40 @@ class DocumentRetriever(BaseRetriever):
         return vector_store.get_documents_by_vector(self.collection, vector)
 
 
+async def _parse_split_and_save(
+    project_id: str, filename: str, file_bytes: bytes, content_type: str | None
+):
+    """
+    Send file for parsing, splitting, and vectorization to the GPU server.
+    """
+    files = {"file": (filename, file_bytes, content_type)}
+    data = {"project_id": project_id}
+
+    timeout_settings = httpx.Timeout(300.0, connect=60.0)  # 5 min total, 1 min connect
+
+    async with httpx.AsyncClient(timeout=timeout_settings) as client:
+        try:
+            print(f"BG: Sending {filename} to GPU server for project {project_id}")
+            response = await client.post(
+                f"{PARSE_SERVER_BASE_URL}/file_parse", files=files, data=data
+            )
+            response.raise_for_status()
+        except httpx.HTTPStatusError as e:
+            print(
+                f"BG: HTTPStatusError for {filename} from GPU server: "
+                f"{e.response.status_code} - {e.response.text}"
+            )
+        except httpx.RequestError as e:
+            print(
+                f"BG: RequestError for {filename}, could not connect to GPU server: "
+                f"{str(e)}"
+            )
+        except Exception as e:
+            print(
+                f"BG: Unexpected error for {filename} during GPU processing: {str(e)}"
+            )
+
+
 async def upload_and_register_document(
     db: Session, project_id: str, file: UploadFile, bucket_name: str = "documents"
 ):
@@ -54,14 +93,19 @@ async def upload_and_register_document(
         content_type=file.content_type,
     )
 
-    # 2. VectorStore에 문서 추가
-    if file.filename.lower().endswith(".pdf"):
-        # Use project_id as the collection name for vector store
-        add_file_to_vector_store(
-            collection_name=project_id,
-            file_content=file_content,
-            file_name=file.filename,
+    # 2. Pass document to GPU server for processing
+    # GPU does the following:
+    #   - Convert file to markdown content
+    #   - Split markdown content into documents
+    #   - Add documents to VectorStore
+    asyncio.create_task(
+        _parse_split_and_save(
+            project_id=project_id,
+            filename=file.filename,
+            file_bytes=file_content,
+            content_type=file.content_type,
         )
+    )
 
     file_url = f"http://{MINIO_URL}/{bucket_name}/{file.filename}"
 
@@ -80,18 +124,133 @@ def list_documents(db: Session, project_id: str):
     return {"documents": documents}
 
 
-def get_document_metadata(db: Session, project_id: str, filename: str):
+def get_document_metadata(
+    db: Session, project_id: str, filename: str
+) -> Document | None:
+    """
+    Returns metadata for the original document, including a presigned URL for
+    downloading.
+
+    Args:
+        db (Session): Database session.
+        project_id (str): Project ID to which the document belongs.
+        filename (str): The ORIGINAL document's filename. (e.g. "report.pdf")
+    """
+    # Look up in DB
     document = get_document_by_filename(db, project_id, filename)
     if not document:
         raise HTTPException(status_code=404, detail="Resource not found")
 
-    # presigned URL 생성
+    # Replace the file URL with presigned URL
     presigned_url = minio_client.presigned_get_object(
-        bucket_name="documents", object_name=filename, expires=timedelta(hours=1)
+        bucket_name="documents",
+        object_name=document.filename,
+        expires=timedelta(hours=1),
     )
 
     document.file_url = presigned_url
     return document
+
+
+def get_markdown_document_metadata(db: Session, project_id: str, filename: str) -> dict:
+    """
+    Returns metadata and content for the markdown version of the document.
+    Note that the image URLs in the markdown content are replaced with presigned URLs.
+
+    Args:
+        db (Session): Database session.
+        project_id (str): Project ID to which the document belongs.
+        filename (str): The ORIGINAL document's filename.
+            (non-markdown version - e.g. "report.pdf")
+
+    Returns:
+        dict: Metadata including filename, upload date, size, and markdown content with
+            image URLs replaced. Upload date is the original document's upload date.
+    """
+    # Look up in DB
+    document = get_document_by_filename(db, project_id, filename)
+    if not document:
+        raise HTTPException(status_code=404, detail="Resource not found")
+
+    # Get the markdown file name
+    original_db_filename = document.filename
+    filename_without_extension = original_db_filename.rsplit(".", 1)[0]
+    markdown_doc_filename = f"{filename_without_extension}.md"
+
+    minio_object_name = f"{project_id}/{markdown_doc_filename}"
+
+    try:
+        # Check existence and get metadata including size
+        object_stat = minio_client.stat_object("markdowns", minio_object_name)
+        markdown_size = object_stat.size
+    except S3Error as e:
+        if e.code == "NoSuchKey":
+            # If the markdown file does not exist, raise a 404 error
+            raise HTTPException(
+                status_code=404,
+                detail=f"Markdown file for {original_db_filename} not found",
+            )
+        # Handle other S3 errors
+        raise HTTPException(
+            status_code=500, detail=f"Error accessing markdown file: {str(e)}"
+        )
+    except Exception as e:
+        # Handle other unexpected errors
+        raise HTTPException(
+            status_code=500, detail=f"Error accessing markdown file: {str(e)}"
+        )
+
+    md_data_response = None
+    try:
+        md_data_response = minio_client.get_object("markdowns", minio_object_name)
+        markdown_content_bytes = md_data_response.read()
+        markdown_content_str = markdown_content_bytes.decode("utf-8")
+    except Exception as e:
+        print(f"Error reading markdown object {minio_object_name}: {e}")
+        raise HTTPException(
+            status_code=500,
+            detail=f"Could not read markdown file for {original_db_filename}",
+        )
+    finally:
+        if md_data_response:
+            md_data_response.close()
+            md_data_response.release_conn()
+
+    def image_url_replacer(match: re.Match[str]) -> str:
+        image_alt_text = match.group(1)
+        image_path = match.group(2)
+
+        # Images are in "images" bucket, object name is the filename directly.
+        try:
+            # Check if image exists in MinIO before generating URL
+            minio_client.stat_object("images", image_path)
+
+            presigned_image_url = minio_client.presigned_get_object(
+                "images", image_path, expires=timedelta(hours=1)
+            )
+            return f"![{image_alt_text}]({presigned_image_url})"
+        # Return original tag if presigning fails
+        except S3Error as e:
+            if e.code == "NoSuchKey":
+                print(f"Image '{image_path}' not found in MinIO.")
+            return match.group(0)
+        except Exception as e:
+            print(f"Error generating presigned URL for image '{image_path}': {e}")
+            return match.group(0)
+
+    # Regex to find markdown image tags: ![alt_text](image_path)
+    # This regex captures alt text in group 1 and image path in group 2.
+    # It assumes image paths do not contain ')'
+    processed_markdown_content = re.sub(
+        r"!\[(.*?)\]\(([^)]+)\)", image_url_replacer, markdown_content_str
+    )
+
+    return {
+        "filename": markdown_doc_filename,
+        "upload_date": document.upload_date,  # Original document's upload date
+        "size": markdown_size,
+        "file_content": processed_markdown_content,
+    }
 
 
 def delete_document(db: Session, project_id: str, filename: str):
@@ -99,12 +258,87 @@ def delete_document(db: Session, project_id: str, filename: str):
     if not document:
         raise HTTPException(status_code=404, detail="Resource not found")
 
-    # MinIO에서 삭제 (object 존재 여부는 확인하지 않음)
+    # Delete the original document from MinIO
     try:
         minio_client.remove_object("documents", filename)
+    except S3Error as e:
+        if e.code == "NoSuchKey":
+            print(f"Document {filename} not found in MinIO. Proceeding.")
+
+    original_db_filename = document.filename
+    filename_without_extension = original_db_filename.rsplit(".", 1)[0]
+    markdown_doc_filename_base = f"{filename_without_extension}.md"
+    minio_object_name = f"{project_id}/{markdown_doc_filename_base}"
+
+    found_markdown_file = False
+
+    md_data_response = None
+    markdown_content_str = ""
+    # Find image filenames referenced in the markdown file
+    try:
+        md_data_response = minio_client.get_object("markdowns", minio_object_name)
+        markdown_content_bytes = md_data_response.read()
+        markdown_content_str = markdown_content_bytes.decode("utf-8")
+        found_markdown_file = True
+    except S3Error as e:
+        if e.code == "NoSuchKey":
+            print(
+                f"Markdown file {minio_object_name} not found. "
+                "Cannot extract image list for deletion."
+            )
+        else:
+            print(f"S3Error reading markdown file {minio_object_name}: {e}")
     except Exception as e:
-        print(f"Error deleting object from MinIO: {e}")
-        pass
+        print(f"Error reading markdown file {minio_object_name}: {e}")
+    finally:
+        if md_data_response:
+            md_data_response.close()
+            md_data_response.release_conn()
+
+    if not found_markdown_file:
+        print(f"Markdown file {minio_object_name} not found. No images to delete.")
+        # Proceed to delete the document from DB
+        delete_document_by_filename(db, project_id, filename)
+        return {"message": "Document deleted successfully", "id": document.id}
+
+    image_filenames_to_delete = []
+    # The regex finds paths within ![](...)
+    image_filenames = re.findall(r"!\[.*?\]\(([^)]+)\)", markdown_content_str)
+    for filename in image_filenames:
+        # Filter out full URLs (should not happen but just in case)
+        if not (filename.startswith("http://") or filename.startswith("https://")):
+            image_filenames_to_delete.append(filename)
+
+    # Delete the markdown file from MinIO
+    try:
+        minio_client.remove_object("markdowns", minio_object_name)
+        print(f"Attempted deletion of markdown file: {minio_object_name}")
+    except S3Error as e:
+        if e.code == "NoSuchKey":
+            print(f"Markdown file {minio_object_name} not found for deletion.")
+        else:
+            print(f"S3Error deleting markdown file {minio_object_name}: {e}")
+    except Exception as e:
+        print(f"Unexpected error deleting markdown file {minio_object_name}: {e}")
+
+    # Delete associated images from MinIO
+    if not image_filenames_to_delete:
+        print("No images found in markdown content for deletion.")
+        delete_document_by_filename(db, project_id, filename)
+        return {"message": "Document deleted successfully", "id": document.id}
+
+    for filename in image_filenames_to_delete:
+        try:
+            # Images are stored in the "images" bucket with the object name
+            # being the filename directly
+            minio_client.remove_object("images", filename)
+        except S3Error as e:
+            if e.code == "NoSuchKey":
+                print(f"Image {filename} not found in bucket 'images' for deletion.")
+            else:
+                print(f"S3Error deleting image {filename} from MinIO: {e}")
+        except Exception as e:
+            print(f"Unexpected error deleting image {filename}: {e}")
 
     # DB에서 삭제
     delete_document_by_filename(db, project_id, filename)

--- a/server/utils/config.py
+++ b/server/utils/config.py
@@ -6,3 +6,4 @@ load_dotenv(override=True)
 
 OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY", "None")
 GOOGLE_API_KEY = os.environ.get("GOOGLE_API_KEY", "None")
+PARSE_SERVER_BASE_URL = os.environ.get("PARSE_SERVER_BASE_URL", "http://localhost:8888")


### PR DESCRIPTION
## 📝 작업 목록
- [x] 마크다운 생성됐는지 확인 및 마크다운 내용 가져오는 엔드포인트 추가
  - 마크다운에 포함된 모든 이미지를 presigned URL로 대체하는 로직 포함
- [x] 유저가 파일 업로드 시 실제 parse, split, vector store에 추가하는 일은 GPU 서버에서 하도록 로직 수정
  - 블로킹되는 것을 막기 위해 `asyncio.create_task` 활용
- [x] 유저가 파일 삭제 시 PDF 파일 뿐 아니라 마크다운 파일, 마크다운에 포함된 이미지 파일도 삭제

## 🔗 관련 이슈
- Closes #38 